### PR TITLE
increased outcomming webhook timeout

### DIFF
--- a/zproject/default_settings.py
+++ b/zproject/default_settings.py
@@ -557,7 +557,7 @@ DEFAULT_DATA_EXPORT_IMPORT_PARALLELISM = (len(os.sched_getaffinity(0)) // 2) or 
 SERVER_UPGRADE_NAG_DEADLINE_DAYS = 30 * 18
 
 # How long servers have to respond to outgoing webhook requests
-OUTGOING_WEBHOOK_TIMEOUT_SECONDS = 10
+OUTGOING_WEBHOOK_TIMEOUT_SECONDS = 60 * 5
 
 # Maximum length of message content allowed.
 # Any message content exceeding this limit will be truncated.


### PR DESCRIPTION
`OUTGOING_WEBHOOK_TIMEOUT_SECONDS` is set to 10 seconds by default. If the bot is unable to answer within `OUTGOING_WEBHOOK_TIMEOUT_SECONDS`, they will resend the message again to our bot. That is the reason why sometimes same response appeared. Our bot normally takes more than 10 seconds, so increasing this to 5 mins is low-haning fruit.
![image](https://github.com/Axe-LLC/zulip/assets/32800747/e62ac06e-a16d-4c99-9fa0-171792e30b17)
